### PR TITLE
Try fix extension b parsing

### DIFF
--- a/src/main/java/org/w3c/tidy/Lexer.java
+++ b/src/main/java/org/w3c/tidy/Lexer.java
@@ -125,6 +125,8 @@ public class Lexer
      * xhtml namespace.
      */
     private static final String XHTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
+    private static boolean illegalChar = false;
+    private static int[] illegalChars = new int[] {-1, -1};
 
     /**
      * lists all the known versions.
@@ -609,7 +611,23 @@ public class Lexer
                 || (c >= 0xE000 && c <= 0xFFFD) // Then high-range unicode.
             || (c >= 0x10000 && c <= 0x10FFFF)))
         {
-            return;
+            if (!illegalChar) {
+                if (illegalChars[0] == -1) {
+                    illegalChars[0] = c;
+                    return;
+                }
+                if (illegalChars[1] == -1) {
+                    illegalChars[1] = c;
+                    illegalChar = true;
+                }
+            }
+
+            if (illegalChar) {
+                int SURROGATE_OFFSET = 0x10000 - (0xD800 << 10) - 0xDC00;
+                c = (illegalChars[0] << 10) + illegalChars[1] + SURROGATE_OFFSET;
+                illegalChar = false;
+                illegalChars = new int[] {-1, -1};
+            }
         }
 
         int i = 0;

--- a/src/main/java/org/w3c/tidy/OutJavaImpl.java
+++ b/src/main/java/org/w3c/tidy/OutJavaImpl.java
@@ -110,7 +110,7 @@ public class OutJavaImpl implements Out
     {
         try
         {
-            writer.write(c);
+            writer.write(Character.toChars(c));
         }
         catch (IOException e)
         {

--- a/src/test/resources/extensionb.cfg
+++ b/src/test/resources/extensionb.cfg
@@ -1,10 +1,12 @@
 # Tidy configuration file for bug #640474
+char-encoding: utf8
 input-xml: yes
 output-xml: yes
 tidy-mark: false
 wrap: 0
 clean: yes
 
+char-encoding= utf8
 input-xml= yes
 output-xml= yes
 tidy-mark= false

--- a/src/test/resources/extensionb.msg
+++ b/src/test/resources/extensionb.msg
@@ -10,33 +10,4 @@
 Tidy (vers 4th August 2004) Parsing "InputStream"
 ]]></text>
   </message>
-  <message>
-    <code>44</code>
-    <level>2</level>
-    <line>1</line>
-    <column>2</column>
-    <text><![CDATA[missing <!DOCTYPE> declaration]]></text>
-  </message>
-  <message>
-    <code>17</code>
-    <level>2</level>
-    <line>1</line>
-    <column>2</column>
-    <text><![CDATA[inserting missing 'title' element]]></text>
-  </message>
-  <message>
-    <code>111</code>
-    <level>0</level>
-    <line>1</line>
-    <column>1</column>
-    <text><![CDATA[InputStream: Document content looks like HTML 2.0]]></text>
-  </message>
-  <message>
-    <code>-1</code>
-    <level>0</level>
-    <line>0</line>
-    <column>0</column>
-    <text><![CDATA[2 warnings, no errors were found!
-]]></text>
-  </message>
 </messages>


### PR DESCRIPTION
When there is an illegal character, it should be combined with the next character and assigned to "c"

When writing, rather call the "write(char[] cbuf)" function as this will handle characters with unicode values greater than 65535